### PR TITLE
[fix]: img optional dimension-parsing capturing group of regx

### DIFF
--- a/src/MarkdownParser.js
+++ b/src/MarkdownParser.js
@@ -16,7 +16,7 @@ var MarkdownParser = class {
 			link: /\[(.+?)\]\((.+?)\)/g,
 			code: /`(.+?)`/g,
 			codeBlock: /```([\s\S]*?)```/g,
-			image: /!\[(.+?)\]\((.+?)\){?(width=\d+ height=\d+)?\}?/g
+			image: /!\[(.+?)\]\((.+?)\)({width=\d+ height=\d+})?/g
 		}
 	};
 	execFn = {

--- a/src/MarkdownParser.tsx
+++ b/src/MarkdownParser.tsx
@@ -20,7 +20,7 @@ class MarkdownParser {
          link: /\[(.+?)\]\((.+?)\)/g,
          code: /`(.+?)`/g,
          codeBlock: /```([\s\S]*?)```/g,
-         image: /!\[(.+?)\]\((.+?)\){?(width=\d+ height=\d+)?\}?/g,
+         image: /!\[(.+?)\]\((.+?)\)({width=\d+ height=\d+})?/g,
       }
    }
    execFn = {


### PR DESCRIPTION
- Fix regx for optionally catching the group for dimension by compulsory checking { and } character are present at the end of the string, then only capture the dimension group